### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -231,12 +231,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "868f4679adc45922ae9b79f262ea64bd0180f58f"
+                "reference": "e09a30f963c393e84de48968fc48cdc2f1a63a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/868f4679adc45922ae9b79f262ea64bd0180f58f",
-                "reference": "868f4679adc45922ae9b79f262ea64bd0180f58f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e09a30f963c393e84de48968fc48cdc2f1a63a5b",
+                "reference": "e09a30f963c393e84de48968fc48cdc2f1a63a5b",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-04-12T00:47:29+00:00"
+            "time": "2025-04-18T00:47:59+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency