### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "9a2e6c0bf6f2d87e1db8d18063a5bedf85040bb2"
+                "reference": "3c17705c9f0d8a18e5d7cd18d87902b065ce9167"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9a2e6c0bf6f2d87e1db8d18063a5bedf85040bb2",
-                "reference": "9a2e6c0bf6f2d87e1db8d18063a5bedf85040bb2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3c17705c9f0d8a18e5d7cd18d87902b065ce9167",
+                "reference": "3c17705c9f0d8a18e5d7cd18d87902b065ce9167",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-09-27T00:45:05+00:00"
+            "time": "2025-10-02T00:46:22+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency