### PR TITLE
fix: Add NoTwoFactorRequired attribute to poll method

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -14,6 +14,7 @@ use OCA\TwoFactorNextcloudNotification\Service\TokenManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoTwoFactorRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
@@ -69,6 +70,7 @@ class APIController extends OCSController {
 		return new DataResponse([], Http::STATUS_OK);
 	}
 
+	#[NoTwoFactorRequired]
 	#[PublicPage]
 	public function poll(string $token): DataResponse {
 		try {


### PR DESCRIPTION
This should allows us to drop the app specific code in server's TwoFactorMiddleware class:

https://github.com/nextcloud/server/blob/6a2e0f819c2d6752b72339e68c4a4eda8d710485/core/Middleware/TwoFactorMiddleware.php#L19

https://github.com/nextcloud/server/blob/6a2e0f819c2d6752b72339e68c4a4eda8d710485/core/Middleware/TwoFactorMiddleware.php#L52-L55

Wasn't an option at the time from what I can tell.

In addition to being ugly, it confuses psalm when the `Controller` parameter type-hint is added in server's TwoFactorMiddleware class (even though it matches the upstream class contract). The 2FA middleware bypass for `APIController` just for this app is also a bit confusing since there truly is an `OCP\AppFramkework\ApiController` that can flow through that middleware too. 

To avoid ugly app specific workarounds like class_exists/etc, I believe we can just use this annotation here now and drop the special bypass for `poll` from the 2fa middlware (unless I'm missing something).