### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: MIT
 9f2b534bea27e8ec2dda7c1d772a664b block-merge-eol.yml
 25fc4c7e69e778e20bdc9eb0cc96367e block-merge-freeze.yml
-4fcd0bffd33680b73724dfd62fae37dd command-compile.yml
+a1c367dbac08581d6565e3b84a0eaf96 command-compile.yml
 7dd8d21d9dd013196cd4bdbf7c24db6f dependabot-approve-merge.yml
-54f293d9abe11ac0035a7bbb96a4e453 lint-eslint.yml
+7bcfba381bfb7c28d9ef6a7d55ac937b lint-eslint.yml
 80a58e5584612def0e751fcfb7669814 lint-info-xml.yml
 ccd8a55c60e35b84becb0f7005ce1286 lint-php-cs.yml
 5dcc3187a9460cb62a455235cbdb3562 lint-php.yml
-cf229fbf443d2f7a303f22eb92745811 lint-stylelint.yml
-c965845a0def7b39d872e47e93dd1139 node.yml
-0b18653741a7e7d377c239a55c5bb062 npm-audit-fix.yml
+bd5b5245dc07b5779031e13817663a3e lint-stylelint.yml
+c98e518ff87d052a1236ac3fc40d2bc1 node.yml
+e54d4276168426a10219333cf10e0d10 npm-audit-fix.yml
 bdca1af74c27de9a9fc2f3c70aabdc8f phpunit-mariadb.yml
 5846b994639ccab0059bf23e141d389a phpunit-mysql.yml
 ec7d1084fbb3a6803dbabf3acdd17ac8 phpunit-oci.yml

--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -124,7 +124,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
           cache: npm

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -68,7 +68,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 

--- a/.github/workflows/lint-stylelint.yml
+++ b/.github/workflows/lint-stylelint.yml
@@ -37,7 +37,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -65,7 +65,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -48,7 +48,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [command-compile.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/command-compile.yml)
- 🆙 Updated [lint-eslint.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-eslint.yml)
- 🆙 Updated [lint-stylelint.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-stylelint.yml)
- 🆙 Updated [node.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/node.yml)
- 🆙 Updated [npm-audit-fix.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/npm-audit-fix.yml)