### PR TITLE
[stable34] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -2,20 +2,20 @@
 # SPDX-License-Identifier: MIT
 9f2b534bea27e8ec2dda7c1d772a664b block-merge-eol.yml
 25fc4c7e69e778e20bdc9eb0cc96367e block-merge-freeze.yml
-46e653f77f1e1054dcf113bf2bab7eab command-compile.yml
+47319d4424574e468e7d0692fd0c61d3 command-compile.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
 2a205b6cc57c26c31a18a7f41190f3e2 lint-eslint.yml
-c5893d7af1998af66d22f8c171ff4448 lint-info-xml.yml
+023b664746d1f2e09a9aaaac772ff7f5 lint-info-xml.yml
 870b483dbcbca59479211270d61546dd lint-php-cs.yml
 ee2b04d185b82fe7dd6fe6d83c6c7b45 lint-php.yml
 351799835db66dd8d20e324970490e96 lint-stylelint.yml
 03759c9dc0fa748cb927b9f9cadf2925 node.yml
 7e9fa275fffbfef58e6348a44750e2ec npm-audit-fix.yml
-8cdb2530228c6e32c4a77ae012873f46 phpunit-mariadb.yml
-07e60b2f304c749ee563f1256caf2793 phpunit-mysql.yml
-b98798d397dd45f12c777038d230509e phpunit-oci.yml
-4bf29a4d193f83443d16d368c60a7870 phpunit-pgsql.yml
-21244b02c3f1ad7d78951ba1b876638f phpunit-sqlite.yml
+5cb2cca6386e45c0c9061192798b37a8 phpunit-mariadb.yml
+d676be1ed03142832d8e712962f5961c phpunit-mysql.yml
+ec26ef77882d1c19cba1ce168f927c2b phpunit-oci.yml
+e92532f6ac32d39a1ff5c5d57b9686ba phpunit-pgsql.yml
+9e8a660a88b8253f33593880710f1df3 phpunit-sqlite.yml
 3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
 20b5d0d45766e3793f19c9c0c8d05140 psalm.yml
 3975dc58817119d596a8f6ed190352ce reuse.yml

--- a/.github/workflows/command-compile.yml
+++ b/.github/workflows/command-compile.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Restore cached git repository
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .git
           key: git-repo

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            appinfo/
 
       - name: Download schema
         run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -67,6 +67,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -68,6 +68,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -67,6 +67,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -67,6 +67,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -67,6 +67,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [command-compile.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/command-compile.yml)
- 🆙 Updated [lint-info-xml.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-info-xml.yml)
- 🆙 Updated [phpunit-mariadb.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mariadb.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
- 🆙 Updated [phpunit-oci.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-oci.yml)
- 🆙 Updated [phpunit-pgsql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-pgsql.yml)
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)