### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "dae68612eb6728af7e98defeca45227c8c4c5ac4"
+                "reference": "ace0c099d516b8f24b32ef085f3d310dfd59fe45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dae68612eb6728af7e98defeca45227c8c4c5ac4",
-                "reference": "dae68612eb6728af7e98defeca45227c8c4c5ac4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ace0c099d516b8f24b32ef085f3d310dfd59fe45",
+                "reference": "ace0c099d516b8f24b32ef085f3d310dfd59fe45",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-07-04T01:51:26+00:00"
+            "time": "2026-07-10T01:50:45+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency