### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ab0d7a274b606f57944ca0a0c2452aa34e39d1ff"
+                "reference": "9fefe399ec692207e376661f47f8834d757e336c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ab0d7a274b606f57944ca0a0c2452aa34e39d1ff",
-                "reference": "ab0d7a274b606f57944ca0a0c2452aa34e39d1ff",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9fefe399ec692207e376661f47f8834d757e336c",
+                "reference": "9fefe399ec692207e376661f47f8834d757e336c",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-07-18T01:22:51+00:00"
+            "time": "2026-07-24T01:42:46+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency