### PR TITLE
fix(routes): bind poll regex constraint to its actual URL placeholder…

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,7 +39,7 @@ return [
 			'verb' => 'GET',
 			'requirements' => [
 				'apiVersion' => 'v1',
-				'attemptId' => '[a-zA-Z0-9]{40}',
+				'token' => '[a-zA-Z0-9]{40}',
 			],
 		],
 	]


### PR DESCRIPTION
… (token)

Since the URL placeholder is {token}, not {attemptId}, the constraint was a silent no-op: any string segment of length >= 1 matched, the framework route compiler never rejected oversized tokens, and only the controller's DoesNotExistException path was protecting the data layer.

The 40-char shape of public tokens (the JS challenge bundle emits them) is now enforced at the router boundary.

- Close #1461

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
